### PR TITLE
commands/fetch_satellites: Replace BaseCommand.option_list with add_arguments

### DIFF
--- a/db/base/management/commands/fetch_satellites.py
+++ b/db/base/management/commands/fetch_satellites.py
@@ -1,4 +1,3 @@
-from optparse import make_option
 from orbit import satellite
 
 from django.core.management.base import BaseCommand, CommandError
@@ -7,18 +6,25 @@ from db.base.models import Satellite
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--delete',
-                    action='store_true',
-                    dest='delete',
-                    default=False,
-                    help='Delete Satellite'),
-    )
-    args = '<Satellite Identifiers>'
     help = 'Updates/Inserts Name for certain Satellites'
 
+    def add_arguments(self, parser):
+        # Positional arguments
+        parser.add_argument('satellite_identifiers',
+                            nargs='+',
+                            metavar='<Satellite Identifier>')
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--delete',
+            action='store_true',
+            dest='delete',
+            default=False,
+            help='Delete Satellite'
+        )
+
     def handle(self, *args, **options):
-        for item in args:
+        for item in options['satellite_identifiers']:
             if options['delete']:
                 try:
                     Satellite.objects.get(norad_cat_id=item).delete()


### PR DESCRIPTION
BaseCommand.option_list is deprecated in Django 1.8
and was removed in Django 1.10.

Fixes #121.